### PR TITLE
Allow custom status url format string.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,10 @@ Below is a sample leeroy config file:
         {
             "github_repo": "docker/docker",
             "jenkins_job_name": "Docker-PRs",
-            "context": "janky" // context to send to github for status (if you
+            "context": "janky", // context to send to github for status (if you
             wanna stack em)
+            "status_link_format": "%s" // format string used to generate details link,
+            defaults to "%s/console"
         }
     ],
 

--- a/handlers.go
+++ b/handlers.go
@@ -81,11 +81,20 @@ func jenkinsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// update the github status
-	if err := config.updateGithubStatus(j.Build.Parameters.GitBaseRepo, build.Context, j.Build.Parameters.GitSha, state, desc, j.Build.Url+"console"); err != nil {
+	statusUrlDefault := "%s/console"
+	statusUrl := fmt.Sprintf(parameterOrDefault(build.StatusLinkFormat, statusUrlDefault), j.Build.Url)
+	if err := config.updateGithubStatus(j.Build.Parameters.GitBaseRepo, build.Context, j.Build.Parameters.GitSha, state, desc, statusUrl); err != nil {
 		log.Error(err)
 	}
 
 	return
+}
+
+func parameterOrDefault(parameter string, defaultValue string) string {
+	if parameter != "" {
+		return parameter;
+	}
+	return defaultValue;
 }
 
 func githubHandler(w http.ResponseWriter, r *http.Request) {

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ type Build struct {
 	Ref              string `json:"ref"`
 	Job              string `json:"jenkins_job_name"`
 	Context          string `json:"context"`
+	StatusLinkFormat string `json:"status_link_format"`
 	Custom           bool   `json:"custom"`
 	HandleIssues     bool   `json:"handle_issues"`
 	SkipStatusUpdate bool   `json:"skip_status_update"`


### PR DESCRIPTION
This PR adds a new config parameter `status_link_format` for builds,
which allows to override the URL used to push back status check reports
to github to a customized URL. This format string is formatted with a
single parameters, the URL to the build on jenkins and defaults to
"%s/console" if it is not specified.